### PR TITLE
Do not include react element

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:4
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ There is an official Rangy module on NPM called [`rangy`](https://www.npmjs.org/
 ## Documentation
 
 View [the documentation in the wiki](https://github.com/timdown/rangy/wiki). 
+
+## Build
+`./builder/build.sh`

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,0 +1,2 @@
+docker build . -t rangy
+docker run -it --rm -v $(pwd):/app rangy node ./builder/build.js

--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -690,7 +690,23 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         },
 
         // Normalizes nodes after applying a class to a Range.
-        postApply: function(textNodes, range, positionsToPreserve, isUndo) {
+        postApply: function(textNodesInput, range, positionsToPreserve, isUndo) {
+
+            var textNodes = []
+            forEach(textNodesInput, function(textNode) {
+                // Ignore the react nodes
+                var parent  = textNode
+                while (parent) {
+                    if (parent._reactRootContainer) {
+                        return
+                    }
+                    parent = parent.parentNode
+                }
+                textNodes.push(textNode)
+                //
+            })
+
+
             log.group("postApply " + range.toHtml());
             var firstNode = textNodes[0], lastNode = textNodes[textNodes.length - 1];
 


### PR DESCRIPTION
ClassApplier will merge adjacent text nodes and adjacent spans marked with its own unique class whenever it acts on a range or selection. Which leads the react does not work as the underline span is merged out of react control